### PR TITLE
Walk iFrames on homepage and login page for increased accuracy, match…

### DIFF
--- a/observability_product_sniffer.rb
+++ b/observability_product_sniffer.rb
@@ -7,7 +7,7 @@ class ObservabilityProductSniffer
 
   def sniff
     options = Selenium::WebDriver::Chrome::Options.new
-    options.add_argument('--headless')
+    # options.add_argument('--headless')
     options.add_argument("--disable-notifications")
     @driver = Selenium::WebDriver.for :chrome, capabilities: options
     @driver.manage.timeouts.page_load = 10 # seconds
@@ -19,39 +19,101 @@ class ObservabilityProductSniffer
       #navigate to homepage
       driver.get(site)
 
+      ###################################################
+      ###################################################
+      ####### CHECK MAIN HOMEPAGE #######################
+      #####  FOR OBSERVABILITY TOOLS ####################
+      ###################################################
+      ###################################################
+
       if !tools_used.empty?
-        detected_on = 'homepage'
-      else
-        # if no observability tool was detected on the homepage,
-        # navigate to login/account/sign in page, because these are more
-        # likely to contain app code and therefore observability monitoring.
+        return {
+          tools_used: tools_used,
+          detected_on: tools_used.empty? ? "n/a" : 'homepage',
+          error: nil
+        }
+      end
 
-        # using elements plural here to avoid error-throwing, and then jsut selecting first result
-        sign_in = driver.find_elements(:xpath, "//a[contains(translate(.,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'sign in')]").map{|el| el.attribute('href')}
-        log_in = driver.find_elements(:xpath, "//a[contains(translate(.,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'log in')]").map{|el| el.attribute('href')}
-        login = driver.find_elements(:xpath, "//a[contains(translate(.,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'login')]").map{|el| el.attribute('href')}
-        account = driver.find_elements(:xpath, "//a[contains(translate(.,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'account')]").map{|el| el.attribute('href')}
+      ###################################################
+      ###################################################
+      ###### CHECK ALL HOMEPAGE FRAMES ##################
+      ######  FOR OBSERVABILITY TOOLS ###################
+      ###################################################
+      ###################################################
 
-        url = nil
-        if !sign_in.empty?
-          detected_on = 'sign in'
-          url = sign_in.first
-        elsif !log_in.empty?
-          detected_on = 'log in'
-          url = log_in.first
-        elsif !login.empty?
-          detected_on = 'login (no space)'
-          url = login.first
-        elsif !account.empty?
-          detected_on = 'account'
-          url = account.first
-        else
-          detected_on = 'n/a'
+      all_frames = driver.find_elements(:css,'iframe')
+      all_frames.each do |frame|
+        # Switch to the frame
+        # check_frame_for_sentry(driver, frame)
+        driver.switch_to.frame frame
+
+        if !tools_used.empty?
+          return {
+            tools_used: tools_used,
+            detected_on: tools_used.empty? ? "n/a" : 'homepage (iframe)',
+            error: nil
+          }
         end
+        
+        driver.switch_to.default_content
+      end
 
-        if url
-          puts "    -> " + url
-          driver.navigate.to url
+      # if no observability tool was detected on the homepage,
+      # navigate to login/account/sign in page, because these are more
+      # likely to contain app code and therefore observability monitoring.
+
+      # using elements plural here to avoid error-throwing, and then jsut selecting first result
+      sign_in = driver.find_elements(:xpath, "//a[contains(translate(.,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'sign in')]").map{|el| el.attribute('href')}
+      signin = driver.find_elements(:xpath, "//a[contains(translate(.,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'signin')]").map{|el| el.attribute('href')}
+      log_in = driver.find_elements(:xpath, "//a[contains(translate(.,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'log in')]").map{|el| el.attribute('href')}
+      login = driver.find_elements(:xpath, "//a[contains(translate(.,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'login')]").map{|el| el.attribute('href')}
+      account = driver.find_elements(:xpath, "//a[contains(translate(.,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'account')]").map{|el| el.attribute('href')}
+
+      url = nil
+      if !sign_in.empty?
+        detected_on = sign_in.first
+        url = sign_in.first
+      elsif !signin.empty?
+        detected_on = signin.first
+        url = signin.first
+      elsif !log_in.empty?
+        detected_on = log_in.first
+        url = log_in.first
+      elsif !login.empty?
+        detected_on = login.first
+        url = login.first
+      elsif !account.empty?
+        detected_on = account.first
+        url = account.first
+      else
+        detected_on = 'n/a'
+      end
+
+      if url
+        puts "    -> " + url
+        driver.navigate.to url
+        
+        ###################################################
+        ###################################################
+        ######## CHECK ALL LOGIN PAGE FRAMES ##############
+        ########  FOR OBSERVABILITY TOOLS #################
+        ###################################################
+        ###################################################
+        all_frames = driver.find_elements(:css,'iframe')
+        all_frames.each do |frame|
+          # Switch to the frame
+          # check_frame_for_sentry(driver, frame)
+          driver.switch_to.frame frame
+          
+          if !tools_used.empty?
+            return {
+              tools_used: tools_used,
+              detected_on: tools_used.empty? ? "n/a" : detected_on,
+              error: nil
+            }
+          end
+          
+          driver.switch_to.default_content
         end
       end
 


### PR DESCRIPTION
…ing Santo plugin functionality

- Santo plugin actually walks all frames on the page (see screenshot where I added `console.log`s). [Github](https://github.com/ndmanvar/detective-scentry/blob/38a44410e88a301a893314f6eac0ff09c1b92195/dist/manifest.json#L32-L36). (We're actually matching against all frames which could be considered a bug -- since this could pick up third party frames as well... so tread carefully)

<img width="1792" alt="Screen Shot 2022-05-12 at 2 37 09 PM" src="https://user-images.githubusercontent.com/12092849/169363300-bc58d50d-e4f5-452d-af0c-fc416de374eb.png">

- So, it's important that the Dogwalk script maintain parity with the chrome extension and also detect observability tools not just on the main homepage, but on any frames embedded within the page. This PR allows for that - we check all frames on the homepage, and if we find a login page, we also check all frames there.